### PR TITLE
Ajout freebox POP (fbxgw8r) et statut WAN

### DIFF
--- a/freebox.py
+++ b/freebox.py
@@ -199,6 +199,21 @@ class FbxApp(FbxCnx):
             Domoticz.Error('Timeout') #on ne fait rien, on retourne une liste vide
         return retour
 
+    def constatus(self):
+        try:
+            v_result = self.get("connection/")
+            if v_result["result"]['state'] == 'up':
+                Domoticz.Log("Connection is UP")
+                return 1
+            else:
+                Domoticz.Log("Connection is DOWN")
+                return 0
+        except (urllib.error.HTTPError, urllib.error.URLError) as error:
+            Domoticz.Error('La Freebox semble indisponible : '+ error.msg)
+        except timeout:
+            Domoticz.Error('Timeout') #on ne fait rien, on retourne une liste vide
+        return 0
+
     def isOnWIFI(self):
         try:
             v_result = self.get("wifi/config/")

--- a/freebox.py
+++ b/freebox.py
@@ -184,9 +184,15 @@ class FbxApp(FbxCnx):
         retour = {}
         try:
             sys = self.com( "system/")
-            retour.update({str('temp_cpub'):str(round(sys["result"]["temp_cpub"],2))})
-            retour.update({str('temp_sw'):str(round(sys["result"]["temp_sw"],2))})
-            retour.update({str('temp_cpum'):str(round(sys["result"]["temp_cpum"],2))})
+            if sys["result"]['board_name'] == 'fbxgw8r':
+                Domoticz.Log("Freebox POP")
+                retour.update({str('temp_cpub'):str(round(sys["result"]["temp_cpub"],2))})
+                retour.update({str('temp_t1'):str(round(sys["result"]["temp_t1"],2))})
+                retour.update({str('temp_t2'):str(round(sys["result"]["temp_t2"],2))})
+            else:
+                retour.update({str('temp_cpub'):str(round(sys["result"]["temp_cpub"],2))})
+                retour.update({str('temp_sw'):str(round(sys["result"]["temp_sw"],2))})
+                retour.update({str('temp_cpum'):str(round(sys["result"]["temp_cpum"],2))})
         except (urllib.error.HTTPError, urllib.error.URLError) as error:
             Domoticz.Error('La Freebox semble indisponible : '+ error.msg)
         except timeout:

--- a/plugin.py
+++ b/plugin.py
@@ -150,7 +150,7 @@ class FreeboxPlugin:
                         v_dev = Domoticz.Device(Unit=keyunit, Name="System "+info, TypeName="Temperature")
                         v_dev.Create()
                         Domoticz.Log("Création du dispositif "+"System "+info)
-
+                
                 #Creation des device presence de la Freebox
                 listeMacString = Parameters["Mode2"]
                 if(listeMacString != ""):
@@ -182,7 +182,16 @@ class FreeboxPlugin:
                     v_dev = Domoticz.Device(Unit=keyunit, Name="Reboot Server", TypeName="Switch")
                     v_dev.Create()
                     Domoticz.Log("Création du dispositif "+"Reboot Server")
-                
+
+                constatus = f.constatus()
+                Domoticz.Log("Etat connexion : "+ str(constatus))
+                keyunit = self.getOrCreateUnitIdForDevice(self.DeviceType.deviceCommande,"WANStatus")
+                if (keyunit not in Devices):
+                    v_dev = Domoticz.Device(Unit=keyunit, Name="WAN Status", TypeName="Switch")
+                    v_dev.Create()
+                    Domoticz.Log("Création du dispositif "+"WAN Status")
+                self.updateDeviceIfExist(self.DeviceType.deviceCommande,"WANStatus",constatus, str(constatus))
+
                 DumpConfigToLog()
         except Exception as e:
             Domoticz.Log("OnStart error: "+str(e))
@@ -262,6 +271,9 @@ class FreeboxPlugin:
 
             v_etatWIFI = f.isOnWIFI()
             self.updateDeviceIfExist(self.DeviceType.deviceCommande,"WIFI",v_etatWIFI, str(v_etatWIFI))
+
+            constatus = f.constatus()
+            self.updateDeviceIfExist(self.DeviceType.deviceCommande,"WANStatus",constatus, str(constatus))
     
         except Exception as e:
             Domoticz.Log("onHeartbeat error: "+str(e))


### PR DESCRIPTION
Compatibilité avec la freebox POP : les sondes de températures n'ont pas les mêmes noms
